### PR TITLE
[WideVine] Added static variable definition

### DIFF
--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -262,6 +262,8 @@ private:
     SessionMap _sessions;
 };
 
+constexpr char WideVine::_certificateFilename[];
+
 static SystemFactoryType<WideVine> g_instance({"video/webm", "video/mp4", "audio/webm", "audio/mp4"});
 
 }  // namespace CDMi


### PR DESCRIPTION
After the filename has been made a static variable within WideVine class, it's definition has to be also provided outside of it. Without it, OCDM-Widevine module does not load properly (missing symbol: _certificateFilename).